### PR TITLE
fix(ADRiAn): Automated fix for dependency update failure

### DIFF
--- a/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/githubrelease/GithubReleaseTask.groovy
+++ b/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/githubrelease/GithubReleaseTask.groovy
@@ -1,4 +1,4 @@
-/* (C) 2024-2025 */
+/* (C) 2024-2026 */
 /* SPDX-License-Identifier: Apache-2.0 */
 package com.fizzpod.gradle.plugins.githubrelease
 
@@ -10,7 +10,9 @@ import org.apache.tika.Tika
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.UntrackedTask
 
+@UntrackedTask(because = "Not worth caching")
 public class GithubReleaseTask extends DefaultTask {
 
     public static final NAME = GithubReleasePlugin.NAME


### PR DESCRIPTION
This commit addresses the build failure caused by updating the `gradle-wrapper` to 9.4.0. The new Gradle version enforces stricter task validation, requiring explicit cacheability annotations. Adding `@UntrackedTask` to `GithubReleaseTask` resolves this.

---
*PR created automatically by Jules for task [17219449709313466262](https://jules.google.com/task/17219449709313466262) started by @boxheed*